### PR TITLE
ER図・README作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,82 @@
-# README
+  # テーブル設計
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+  ## users テーブル
 
-Things you may want to cover:
+  | Column             | Type   | Options     |
+  | ------------------ | ------ | ----------- |
+  | nickname           | string | null: false |
+  | email              | string | null: false, unique: true |
+  | encrypted_password | string | null: false |
+  | last_name          | string | null: false |
+  | first_name         | string | null: false |
+  | last_name_kana     | string | null: false |
+  | first_name_kana    | string | null: false |
+  | birth_date         | date   | null: false |
 
-* Ruby version
+  ### Association
 
-* System dependencies
+  - has_many :items
+  - has_many :purchases
+  - has_many :comments
 
-* Configuration
+  ## items テーブル
 
-* Database creation
+  | Column           | Type       | Options     |
+  | ---------------- | ---------- | ----------- |
+  | name             | string     | null: false |
+  | description      | text       | null: false |
+  | category_id      | integer    | null: false |
+  | condition_id     | integer    | null: false |
+  | shipping_fee_id  | integer    | null: false |
+  | prefecture_id    | integer    | null: false |
+  | shipping_days_id | integer    | null: false |
+  | price            | integer    | null: false |
+  | user             | references | null: false, foreign_key: true |
 
-* Database initialization
+  ### Association
 
-* How to run the test suite
+  - belongs_to :user
+  - has_one :purchase
+  - has_many :comments
 
-* Services (job queues, cache servers, search engines, etc.)
+  ## purchases テーブル
 
-* Deployment instructions
+  | Column | Type       | Options                        |
+  | ------ | ---------- | ------------------------------ |
+  | user   | references | null: false, foreign_key: true |
+  | item   | references | null: false, foreign_key: true |
 
-* ...
+  ### Association
+
+  - belongs_to :user
+  - belongs_to :item
+  - has_one :address
+
+  ## addresses テーブル
+
+  | Column        | Type       | Options     |
+  | ------------- | ---------- | ----------- |
+  | postal_code   | string     | null: false |
+  | prefecture_id | integer    | null: false |
+  | city          | string     | null: false |
+  | address       | string     | null: false |
+  | building_name | string     |             |
+  | phone_number  | string     | null: false |
+  | purchase      | references | null: false, foreign_key: true |
+
+  ### Association
+
+  - belongs_to :purchase
+
+  ## comments テーブル
+
+  | Column       | Type       | Options     |
+  | ------------ | ---------- | ----------- |
+  | comment_text | text       | null: false |
+  | user         | references | null: false, foreign_key: true |
+  | item         | references | null: false, foreign_key: true |
+
+  ### Association
+
+  - belongs_to :user
+  - belongs_to :item

--- a/er_diagram.dio
+++ b/er_diagram.dio
@@ -1,0 +1,129 @@
+<mxfile host="65bd71144e">
+    <diagram id="bMUOyWNcThtndxkHQN5i" name="ページ1">
+        <mxGraphModel dx="746" dy="419" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="#ffffff" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="59" value="Items" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;labelBackgroundColor=#FFFFFF;fontColor=#000000;" parent="1" vertex="1">
+                    <mxGeometry x="310" y="150" width="160" height="170" as="geometry"/>
+                </mxCell>
+                <mxCell id="60" value="+name&#10;+description&#10;+category_id&#10;+condition_id&#10;+shipping_fee_id&#10;+prefecture_id&#10;+shipping_days_id&#10;+price&#10;+user" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="59" vertex="1">
+                    <mxGeometry y="30" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="61" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;" parent="59" vertex="1">
+                    <mxGeometry y="120" width="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="62" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;" parent="59" vertex="1">
+                    <mxGeometry y="120" width="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="63" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;" parent="59" vertex="1">
+                    <mxGeometry y="120" width="160" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="69" value="Shipping_fee(active_hash)" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;labelBackgroundColor=#FFFFFF;fontColor=#000000;" parent="1" vertex="1">
+                    <mxGeometry x="270" y="450" width="180" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="70" value="+shipping_fee" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;labelBackgroundColor=#FFFFFF;fontColor=#000000;" parent="69" vertex="1">
+                    <mxGeometry y="30" width="180" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="111" style="edgeStyle=none;html=1;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.75;entryDx=0;entryDy=0;startArrow=none;startFill=0;endArrow=none;endFill=0;" parent="1" source="71" target="63" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="71" value="Shipping_days(active_hash)" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;" parent="1" vertex="1">
+                    <mxGeometry x="520" y="360" width="180" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="72" value="+shipping_days" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;" parent="71" vertex="1">
+                    <mxGeometry y="30" width="180" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="110" style="edgeStyle=none;html=1;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0.85;entryY=1.067;entryDx=0;entryDy=0;entryPerimeter=0;startArrow=none;startFill=0;endArrow=none;endFill=0;" parent="1" source="75" target="63" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="75" value="Condition(active_hash)" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;labelBackgroundColor=default;" parent="1" vertex="1">
+                    <mxGeometry x="470" y="450" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="105" style="edgeStyle=none;html=1;exitX=1;exitY=0;exitDx=0;exitDy=0;startArrow=ERmandOne;startFill=0;endArrow=ERzeroToMany;endFill=0;" parent="75" source="76" target="75" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="76" value="+condition" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;" parent="75" vertex="1">
+                    <mxGeometry y="30" width="160" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="73" value="Prefecture(active_hash)" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;" parent="1" vertex="1">
+                    <mxGeometry x="540" y="260" width="170" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="74" value="+prefecture" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;" parent="73" vertex="1">
+                    <mxGeometry y="30" width="170" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="79" value="Addresses" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="1" vertex="1">
+                    <mxGeometry x="500" y="80" width="160" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="80" value="+postal_code&#10;+prefecture_id&#10;+city&#10;+address&#10;+building_name&#10;+phone_number&#10;+purchase" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;" parent="79" vertex="1">
+                    <mxGeometry y="30" width="160" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="98" style="edgeStyle=none;html=1;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;startArrow=ERmandOne;startFill=0;endArrow=ERzeroToMany;endFill=0;" parent="1" source="85" target="89" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="85" value="Users" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="1" vertex="1">
+                    <mxGeometry x="80" y="150" width="160" height="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="86" value="+nickname&#10;+email&#10;+encrypted_password&#10;+last_name&#10;+first_name&#10;+last_name_kana&#10;+first_name_kana&#10;+birth_date" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="85" vertex="1">
+                    <mxGeometry y="30" width="160" height="130" as="geometry"/>
+                </mxCell>
+                <mxCell id="88" value="Purchases" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;labelBackgroundColor=#FFFFFF;fontColor=#000000;" parent="1" vertex="1">
+                    <mxGeometry x="270" y="50" width="160" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="89" value="+user&#10;+item" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="88" vertex="1">
+                    <mxGeometry y="30" width="160" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="82" value="Comments" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="370" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="83" value="+comment_text&#10;+item&#10;+user" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;labelBackgroundColor=#FFFFFF;fontColor=#000000;" parent="82" vertex="1">
+                    <mxGeometry y="30" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="94" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;endArrow=ERmandOne;endFill=0;startArrow=ERzeroToMany;startFill=0;" parent="1" source="82" target="86" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="95" style="edgeStyle=none;html=1;exitX=0.838;exitY=-0.044;exitDx=0;exitDy=0;startArrow=ERzeroToMany;startFill=0;endArrow=ERmandOne;endFill=0;exitPerimeter=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" parent="1" source="82" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="310" y="292.5" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="99" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;startArrow=ERmandOne;startFill=0;endArrow=ERmandOne;endFill=0;" parent="1" source="89" target="59" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="100" style="edgeStyle=none;html=1;startArrow=ERmandOne;startFill=0;endArrow=ERmandOne;endFill=0;exitX=1;exitY=0.25;exitDx=0;exitDy=0;" parent="1" source="89" target="80" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="450" y="80" as="sourcePoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="102" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;startArrow=ERmandOne;startFill=0;endArrow=ERzeroToMany;endFill=0;" parent="1" source="86" target="60" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="103" style="edgeStyle=none;html=1;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;startArrow=none;startFill=0;endArrow=none;endFill=0;" parent="1" target="74" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="470" y="270" as="sourcePoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="104" style="edgeStyle=none;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.25;entryY=0;entryDx=0;entryDy=0;startArrow=none;startFill=0;endArrow=none;endFill=0;" parent="1" source="80" target="73" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="107" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;startArrow=none;startFill=0;endArrow=none;endFill=0;" parent="1" source="65" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="320" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="65" value="Category(active_hash)" style="swimlane;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;rounded=1;fontSize=14;fontStyle=0;strokeWidth=2;resizeParent=0;resizeLast=1;shadow=0;dashed=0;align=center;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="370" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="66" value="+category" style="align=left;strokeColor=none;fillColor=none;spacingLeft=4;fontSize=12;verticalAlign=top;resizable=0;rotatable=0;part=1;fontColor=#000000;labelBackgroundColor=#FFFFFF;" parent="65" vertex="1">
+                    <mxGeometry y="30" width="160" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="109" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;startArrow=none;startFill=0;endArrow=none;endFill=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="420" y="320" as="targetPoint"/>
+                        <mxPoint x="430" y="450" as="sourcePoint"/>
+                    </mxGeometry>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
#What
-ER図を作成し、アプリケーション全体のデータ構造を可視化
 -必要なテーブル（users、items、purchases、addresses、comments）を定義
 -各テーブルのカラム名、データ型、制約を明記
 -テーブル間のリレーションを整理（has_many、belongs_to、has_oneを使用）

-READMEにデータベース設計を記述
 -テーブル名、カラム名、データ型、制約（null: false、foreign_key: true）を記載
 -各モデル間のアソシエーションを記述

#Why
-ER図の目的
 -アプリケーションのデータ構造を一目で把握できるようにするため
-READMEの目的
 -データベース設計をコードとして残すことで、今後の実装における指針とするため
 -テーブルやリレーションに変更が生じた際に簡単に追跡できるようにするため

#ER図の画像
https://i.gyazo.com/e6cef9a43e6e7183b891e8655ca53fac.png